### PR TITLE
Iotdb 763 add test for client py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,10 @@ matrix:
         - export "PATH=/c/mvn363/apache-maven-3.6.3/bin:$PATH"
       script:
         - mvn -P site clean package -pl site
+    - language: python
+      python: 3.7
+      script:
+        - python -m unittest client-py/tests/test_client.py
 cache:
   directories:
     - '$HOME/.m2/repository'

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,9 @@ matrix:
         - mvn -P site clean package -pl site
     - language: python
       python: 3.7
+      cache: pip
+      install:
+        - pip install -r client-py/requirements.txt
       script:
         - python -m unittest client-py/tests/test_client.py
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,8 +157,9 @@ matrix:
       python: 3.7
       cache: pip
       install:
-        - pip install -r client-py/requirements.txt
+        - pip install thrift
       script:
+        - mvn clean install -DskipTests
         - python -m unittest client-py/tests/test_client.py
 cache:
   directories:

--- a/client-py/tests/test_client.py
+++ b/client-py/tests/test_client.py
@@ -1,4 +1,21 @@
 #!/usr/bin/env python3
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
 import unittest
 import subprocess
 import os

--- a/client-py/tests/test_client.py
+++ b/client-py/tests/test_client.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import unittest
+import subprocess
+import os
+
+class TestBasic(unittest.TestCase):
+
+    def test_functionality(self):
+        path = os.path.dirname(os.path.realpath(__file__))
+        self.assertEqual(subprocess.run(['python3', f'{path}/../src/client_example.py']).returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed Apache Header in test_client.py

Notice: Every file has to have an Apache Header otherwise rat plugin will fail.